### PR TITLE
feat(exec): add Ramus binary, expose --include-plan-tool flag, and us…

### DIFF
--- a/codex-rs/exec/Cargo.toml
+++ b/codex-rs/exec/Cargo.toml
@@ -7,6 +7,10 @@ version = { workspace = true }
 name = "codex-exec"
 path = "src/main.rs"
 
+[[bin]]
+name = "ramus"
+path = "src/bin/ramus.rs"
+
 [lib]
 name = "codex_exec"
 path = "src/lib.rs"

--- a/codex-rs/exec/src/bin/ramus.rs
+++ b/codex-rs/exec/src/bin/ramus.rs
@@ -1,0 +1,29 @@
+use clap::Parser;
+use codex_arg0::arg0_dispatch_or_else;
+use codex_common::CliConfigOverrides;
+use codex_exec::Cli;
+use codex_exec::run_main;
+
+#[derive(Parser, Debug)]
+struct TopCli {
+    #[clap(flatten)]
+    config_overrides: CliConfigOverrides,
+
+    #[clap(flatten)]
+    inner: Cli,
+}
+
+fn main() -> anyhow::Result<()> {
+    arg0_dispatch_or_else(|codex_linux_sandbox_exe| async move {
+        let top_cli = TopCli::parse();
+        // Merge root-level overrides into inner CLI struct so downstream logic remains unchanged.
+        let mut inner = top_cli.inner;
+        inner
+            .config_overrides
+            .raw_overrides
+            .splice(0..0, top_cli.config_overrides.raw_overrides);
+
+        run_main(inner, codex_linux_sandbox_exe).await?;
+        Ok(())
+    })
+}

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -91,6 +91,10 @@ pub struct Cli {
     #[arg(long = "emit-plan-stdout")]
     pub emit_plan_stdout: bool,
 
+    /// Include the experimental plan tool so the model can call `update_plan`.
+    #[arg(long = "include-plan-tool", default_value_t = false)]
+    pub include_plan_tool: bool,
+
     /// Initial instructions for the agent. If not provided as an argument (or
     /// if `-` is used), instructions are read from stdin.
     #[arg(value_name = "PROMPT")]


### PR DESCRIPTION
 feat(exec): add Ramus binary, plan webhooks, and include-plan-tool flag


- Overview:
  - Adds Ramus plan event emission (webhook, files, stdout) wired to UpdatePlanArgs.
  - Introduces a `ramus` binary alias for easier invocation.
  - Exposes `--include-plan-tool` in exec mode so the model can call `update_plan`.
  - Uses the configured model in `meta.model`.
 
- Changes:
  - `exec/src/plan_emitter.rs`: HMAC signing (v0:{X-Timestamp}:{raw_body}), jittered retries, atomic plan.json, events.jsonl append, sequence persistence, stdout `@plan` lines.
  - `exec/src/cli.rs`: new flags (`--plan-webhook`, `--webhook-secret`, `--plan-events`, `--plan-state`, `--task-id`, `--run-id`, `--emit-plan-stdout`, `--include-plan-tool`).
  - `exec/src/lib.rs`: emitter wiring, safe SIGTERM handling.
  - `exec/Cargo.toml` + `exec/src/bin/ramus.rs`: adds `ramus` binary.
- Testing:
  - Exec crate: clippy clean; unit + integration tests pass.
  - Workspace: green except one env-specific zsh detection test (unrelated).
  - Local smoke validated with `--include-plan-tool`.
- Backward compatibility: All features are opt-in via flags; defaults unchanged.
- Deployment: Runner must pass `--include-plan-tool`. Webhook headers: X-Run-Id, X-Task-Id, X-Seq, X-Timestamp (RFC3339), X-Signature.
